### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show,]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   def index
     @items = Item.all.order("created_at DESC")
   end
@@ -34,6 +34,11 @@ class ItemsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
    end
+
+   def destroy
+    @item.destroy
+    redirect_to root_path
+  end
 
   private
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show,]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_index, only: [:edit, :destroy]
+
   def index
     @items = Item.all.order("created_at DESC")
   end
@@ -22,9 +24,7 @@ class ItemsController < ApplicationController
   end
 
   def edit 
-    unless user_signed_in? && current_user.id == @item.user_id 
-      redirect_to action: :index
-    end
+    
   end
 
   def update
@@ -47,5 +47,11 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def move_to_index
+    unless current_user.id == @item.user_id 
+      redirect_to action: :index
+    end
   end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if user_signed_in? && current_user.id == @item.user.id %>
       <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", item_path, data: {turbo_method: :delete}, class:"item-destroy" %>
     <% elsif user_signed_in?%>
 
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
商品削除機能の実装
# Why
フリーマーケットサイトを再現するために必要な商品削除機能を実装したため
# 動画
・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる
https://gyazo.com/5d73d7733d4d8aae67e3c08f776c1fe9